### PR TITLE
Add DynamoDB table scan rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For details about Spark SQL schemas, see
 
 | Option | Description |
 | --- | --- |
-| `read_capacity_pct` | Percent of provisioned read capacity to use. Default: `20` |
+| `rate_limit_per_segment` | Max number of read capacity units per second each scan segment will consume from the DynamoDB table. Default: no rate limit |
 | `page_size` | Scan page size. Default: `1000` |
 | `segments` | Number of segments to scan the DynamoDB table with. |
 | `aws_credentials_provider_chain` | Class name of the AWS provider chain to use when connecting to DynamoDB. |

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DefaultSource.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DefaultSource.scala
@@ -31,7 +31,6 @@ private[dynamodb] class DefaultSource
       throw new IllegalArgumentException("Required parameter 'table' was unspecified.")
     )
 
-    // Update docs if the read_capacity_pct default is changed.
     val readCapacityPct = Integer.parseInt(parameters.getOrElse("read_capacity_pct", "20"))
 
     new DynamoDBRelation(
@@ -39,6 +38,7 @@ private[dynamodb] class DefaultSource
       maybePageSize = parameters.get("page_size"),
       maybeRegion = parameters.get("region"),
       maybeSegments = parameters.get("segments"),
+      maybeRateLimit = parameters.get("rate_limit_per_segment").map(Integer.parseInt),
       maybeSchema = maybeSchema,
       maybeCredentials = parameters.get("aws_credentials_provider_chain"),
       maybeEndpoint = parameters.get("endpoint"))(sqlContext)

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
@@ -11,12 +11,14 @@ import com.amazonaws.services.dynamodbv2.document.Table
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
 import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
 import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder
+import com.google.common.util.concurrent.RateLimiter
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.sources._
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.sources.PrunedScan
+import org.apache.spark.sql.types.StructType
 
 import scala.collection.JavaConversions.asScalaIterator
 import scala.util.control.NonFatal
@@ -26,6 +28,8 @@ import scala.util.control.NonFatal
   * @param tableName Name of the DynamoDB table to scan.
   * @param maybePageSize DynamoDB request page size.
   * @param maybeSegments Number of segments to scan the table with.
+  * @param maybeRateLimit Max number of read capacity units per second each scan segment will consume from
+  *   the DynamoDB table.
   * @param maybeRegion AWS region of the table to scan.
   * @param maybeSchema Schema of the DynamoDB table.
   * @param maybeCredentials By default, [[com.amazonaws.auth.DefaultAWSCredentialsProviderChain]]
@@ -38,6 +42,7 @@ private[dynamodb] case class DynamoDBRelation(
   tableName: String,
   maybePageSize: Option[String],
   maybeSegments: Option[String],
+  maybeRateLimit: Option[Int],
   maybeRegion: Option[String],
   maybeSchema: Option[StructType],
   maybeCredentials: Option[String] = None,
@@ -71,13 +76,13 @@ private[dynamodb] case class DynamoDBRelation(
   override def schema: StructType = TableSchema
 
   override def buildScan(requiredColumns: Array[String]): RDD[Row] = {
-    // TODO(travis): Add rate limiter back in.
     // TODO(travis): Add items scanned logging back in.
 
     val segments = 0 until Segments
     val scanConfigs = segments.map(idx => {
       ScanConfig(schema, requiredColumns, tableName, segment = idx,
-        totalSegments = segments.length, pageSize, maybeCredentials, maybeRegion, maybeEndpoint)
+        totalSegments = segments.length, pageSize, maybeRateLimit = maybeRateLimit,
+        maybeCredentials, maybeRegion, maybeEndpoint)
     })
 
     val tableDesc = Table.describe()
@@ -137,10 +142,15 @@ private object DynamoDBRelation extends Logging {
 
     val failureCounter = new AtomicLong()
 
+    val maybeRateLimiter = config.maybeRateLimit.map(rateLimit => {
+      log.info(s"Segment ${config.segment} using rate limit of $rateLimit")
+      RateLimiter.create(rateLimit)
+    })
+
     // Each `pages.next` call results in a DynamoDB network call.
     result.pages().iterator().flatMap(page => {
       // This result set resides in local memory.
-      page.iterator().flatMap(item => {
+      val rows = page.iterator().flatMap(item => {
         try {
           Some(ItemConverter.toRow(item, config.schema))
         } catch {
@@ -152,6 +162,23 @@ private object DynamoDBRelation extends Logging {
             None
         }
       })
+
+      // Blocks until rate limit is available.
+      maybeRateLimiter.foreach(rateLimiter => {
+        // DynamoDBLocal.jar does not implement consumed capacity
+        val maybeConsumedCapacityUnits = Option(page.getLowLevelResult.getScanResult.getConsumedCapacity)
+          .map(_.getCapacityUnits)
+          .map(math.ceil(_).toInt)
+
+        maybeConsumedCapacityUnits.foreach(consumedCapacityUnits => {
+          val waited = rateLimiter.acquire(consumedCapacityUnits)
+          if (waited >= 1) {
+            log.info(s"Segment ${config.segment} waited $waited seconds before making this request.")
+          }
+        })
+      })
+
+      rows
     })
   }
 }
@@ -163,6 +190,7 @@ private case class ScanConfig(
   segment: Int,
   totalSegments: Int,
   pageSize: Int,
+  maybeRateLimit: Option[Int],
   maybeCredentials: Option[String],
   maybeRegion: Option[String],
   maybeEndpoint: Option[String])

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationSpec.scala
@@ -53,6 +53,7 @@ class DynamoDBRelationSpec() extends FlatSpec with Matchers {
   it should "get attributes in the inferred schema" in {
     val usersDF = sqlContext.read
       .option(EndpointKey, LocalDynamoDBEndpoint)
+      .option("rate_limit_per_segment", "1")
       .dynamodb(TestUsersTableName)
 
     usersDF.collect() should contain theSameElementsAs Seq(Row(1, "a"), Row(2, "b"), Row(3, "c"))


### PR DESCRIPTION
Here we add support for the `rate_limit_per_segment` option. We use a Guava
RateLimiter for each scan segments that treats DynamoDB consumed read capacity
units as RateLimiter permits.

Connects to #9