### PR TITLE
Add an RDD-based DynamoDB scanner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # DynamoDB Data Source for Apache Spark
 
 This library provides support for reading an [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)
-table as an [Apache Spark](https://spark.apache.org/) DataFrame. Users can run ad-hoc SQL
-queries directly against DynamoDB tables, and easily build ETL pipelines that load
-DynamoDB tables into another system. This library was created by the Product Science team
-at [Medium](https://medium.com/).
+table with [Apache Spark](https://spark.apache.org/).
+
+Tables can be read directly as a DataFrame, or as an RDD of stringified JSON. Users can run ad-hoc
+SQL queries directly against DynamoDB tables, and easily build ETL pipelines that load DynamoDB
+tables into another system. This library was created by the Data Platform team at
+[Medium](https://medium.com/).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
 - [Installation](#installation)
-- [Usage](#usage)
-- [Schemas](#schemas)
-- [Configuration](#configuration)
+- [DataFrame Usage](#dataframe-usage)
+  - [Schemas](#schemas)
+  - [Configuration](#configuration)
+- [RDD Usage](#rdd-usage)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -35,7 +38,7 @@ Start a spark shell with this library as a dependency:
 $ spark-shell --packages com.github.traviscrawford:spark-dynamodb:0.0.2
 ```
 
-## Usage
+## DataFrame Usage
 
 You can register a DynamoDB table and run SQL queries against it, or query with the Spark SQL DSL.
 The schema will be inferred by sampling items in the table, or you can provide your own schema.
@@ -57,7 +60,7 @@ val data = sqlContext.sql("select username from users where username = 'tc'")
 val data2 = users.select("username").filter($"username" = "tc")
 ```
 
-## Schemas
+### Schemas
 
 DynamoDB tables do not have a schema beyond the primary key(s). If no schema is provided,
 the schema will be inferred from a sample of items in the table. If items with multiple
@@ -77,7 +80,7 @@ val schema = StructType(Seq(
 For details about Spark SQL schemas, see
 [StructType](http://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.sql.types.StructType).
 
-## Configuration
+### Configuration
 
 | Option | Description |
 | --- | --- |
@@ -86,3 +89,36 @@ For details about Spark SQL schemas, see
 | `segments` | Number of segments to scan the DynamoDB table with. |
 | `aws_credentials_provider_chain` | Class name of the AWS provider chain to use when connecting to DynamoDB. |
 | `endpoint` | DynamoDB client endpoint in `http://localhost:8000` format. This is generally not needed and intended for unit tests. |
+
+## RDD Usage
+
+Like most NoSQL databases, DynamoDB does not strictly enforce schemas. For this reason it may not be appropriate to
+load your DynamoDB tables as Spark DataFrames. This library provides support for loading DynamoDB tables as
+`RDD[String]` containing stringified JSON.
+
+Scan a table from the command-line with the following command. Spark requires the name of your job jar,
+though you may not have one when scanning a table - simply put a placeholder name to satisfy the launcher script.
+
+```bash
+spark-submit \
+  --class com.github.traviscrawford.spark.dynamodb.DynamoBackupJob \
+  --packages com.github.traviscrawford:spark-dynamodb:0.0.4-SNAPSHOT \
+  fakeJar
+```
+
+The following flags are supported:
+
+```
+usage: com.github.traviscrawford.spark.dynamodb.DynamoBackupJob$ [<flag>...]
+flags:
+  -credentials='java.lang.String': Optional AWS credentials provider class name.
+  -help='false': Show this help
+  -output='java.lang.String': Path to write the DynamoDB table backup.
+  -pageSize='1000': Page size of each DynamoDB request.
+  -rateLimit='Int': Max number of read capacity units per second each scan segment will consume.
+  -region='java.lang.String': Region of the DynamoDB table to scan.
+  -table='java.lang.String': DynamoDB table to scan.
+  -totalSegments='1': Number of DynamoDB parallel scan segments.
+```
+
+To integrate with your own code, see `DynamoScanner`.

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,11 @@
       <version>1.10.68</version>
     </dependency>
     <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>util-app_2.10</artifactId>
+      <version>6.34.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_2.10</artifactId>
       <version>1.6.1</version>

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoBackupJob.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoBackupJob.scala
@@ -1,0 +1,42 @@
+package com.github.traviscrawford.spark.dynamodb
+
+/** Backup a DynamoDB table as JSON.
+  *
+  * The full table is scanned and the results are stored in the given output path.
+  */
+object DynamoBackupJob extends Job {
+  val region = flag[String]("region", "Region of the DynamoDB table to scan.")
+
+  val table = flag[String]("table", "DynamoDB table to scan.")
+
+  val totalSegments = flag("totalSegments", 1, "Number of DynamoDB parallel scan segments.")
+
+  val pageSize = flag("pageSize", 1000, "Page size of each DynamoDB request.")
+
+  val output = flag[String]("output", "Path to write the DynamoDB table backup.")
+
+  val credentials = flag[String]("credentials", "Optional AWS credentials provider class name.")
+
+  val rateLimit = flag[Int]("rateLimit",
+    "Max number of read capacity units per second each scan segment will consume.")
+
+  def run(): Unit = {
+    val maybeCredentials = credentials.isDefined match {
+      case true => Some(credentials())
+      case false => None
+    }
+
+    val maybeRateLimit = rateLimit.isDefined match {
+      case true => Some(rateLimit())
+      case false => None
+    }
+
+    val maybeRegion = region.isDefined match {
+      case true => Some(region())
+      case false => None
+    }
+
+    DynamoScanner(sc, table(), totalSegments(), pageSize(),
+      maybeCredentials, maybeRateLimit, maybeRegion).saveAsTextFile(output())
+  }
+}

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoScanner.scala
@@ -1,0 +1,97 @@
+package com.github.traviscrawford.spark.dynamodb
+
+import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
+import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+import com.google.common.util.concurrent.RateLimiter
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConversions.asScalaIterator
+
+/** Scan a DynamoDB table in parallel and return items as stringified JSON.
+  *
+  * Amazon recommends table scans "Avoid Sudden Bursts of Read Activity", and documents
+  * how to "Reduce Page Size" as a technique to achieve an even distribution of requests and size.
+  * For details, see:
+  * http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScanGuidelines.html
+  */
+object DynamoScanner {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  def apply(
+    sc: SparkContext,
+    table: String,
+    totalSegments: Int,
+    pageSize: Int,
+    maybeCredentials: Option[String] = None,
+    maybeRateLimit: Option[Int] = None,
+    maybeRegion: Option[String] = None,
+    maybeEndpoint: Option[String] = None)
+  : RDD[String] = {
+
+    val segments = 0 until totalSegments
+    val scanConfigs = segments.map(idx => {
+      BackupConfig(
+        table = table,
+        segment = idx,
+        totalSegments = segments.length,
+        pageSize = pageSize,
+        maybeRateLimit = maybeRateLimit,
+        maybeCredentials = maybeCredentials,
+        maybeRegion = maybeRegion,
+        maybeEndpoint = maybeEndpoint)
+    })
+
+    sc.parallelize(scanConfigs, scanConfigs.length).flatMap(scan)
+  }
+
+  private def scan(config: BackupConfig): Iterator[String] = {
+    val maybeRateLimiter = config.maybeRateLimit.map(rateLimit => {
+      log.info(s"Segment ${config.segment} using rate limit of $rateLimit")
+      RateLimiter.create(rateLimit)
+    })
+
+    val table = DynamoDBRelation.getTable(
+      tableName = config.table,
+      maybeCredentials = config.maybeCredentials,
+      maybeRegion = config.maybeRegion,
+      maybeEndpoint = config.maybeEndpoint)
+
+    val scanSpec = new ScanSpec()
+      .withMaxPageSize(config.pageSize)
+      .withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
+      .withTotalSegments(config.totalSegments)
+      .withSegment(config.segment)
+
+    val result = table.scan(scanSpec)
+
+    // Each `pages.next` call results in a DynamoDB network call.
+    result.pages().iterator().flatMap(page => {
+      // Blocks until rate limit is available.
+      maybeRateLimiter.foreach(rateLimiter => {
+        // DynamoDBLocal.jar does not implement consumed capacity
+        val maybeConsumedCapacityUnits = Option(page.getLowLevelResult.getScanResult.getConsumedCapacity)
+          .map(_.getCapacityUnits)
+          .map(math.ceil(_).toInt)
+
+        maybeConsumedCapacityUnits.foreach(consumedCapacityUnits => {
+          rateLimiter.acquire(consumedCapacityUnits)
+        })
+      })
+
+      // This result set resides in local memory.
+      page.iterator().map(_.toJSON)
+    })
+  }
+}
+
+private case class BackupConfig(
+  table: String,
+  segment: Int,
+  totalSegments: Int,
+  pageSize: Int,
+  maybeRateLimit: Option[Int] = None,
+  maybeCredentials: Option[String] = None,
+  maybeRegion: Option[String] = None,
+  maybeEndpoint: Option[String] = None)

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/Job.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/Job.scala
@@ -1,0 +1,37 @@
+package com.github.traviscrawford.spark.dynamodb
+
+import com.twitter.app.FlagParseException
+import com.twitter.app.FlagUsageError
+import com.twitter.app.Flags
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkConf
+import org.slf4j.LoggerFactory
+
+/** Base class for Spark jobs. */
+trait Job {
+  protected val log = LoggerFactory.getLogger(this.getClass)
+  protected val name: String = getClass.getName.stripSuffix("$")
+
+  protected val flag: Flags =
+    new Flags(this.getClass.getName, includeGlobal = true, failFastUntilParsed = true)
+
+  lazy val conf = new SparkConf().setAppName(getClass.getName)
+  lazy implicit val sc = SparkContext.getOrCreate(conf)
+
+  /** Users should override this method with their Spark job logic. */
+  def run(): Unit
+
+  def main(args: Array[String]): Unit = {
+    flag.parseArgs(args, allowUndefinedFlags = false) match {
+      case Flags.Ok(remainder) =>
+      case Flags.Help(usage) => throw FlagUsageError(usage)
+      case Flags.Error(reason) => throw FlagParseException(reason)
+    }
+
+    try {
+      run()
+    } finally {
+      sc.stop()
+    }
+  }
+}

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/BaseSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/BaseSpec.scala
@@ -1,0 +1,67 @@
+package com.github.traviscrawford.spark.dynamodb
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import com.amazonaws.services.dynamodbv2.document.Item
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput
+import com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
+import org.scalatest._
+
+import scala.collection.JavaConversions._
+
+trait BaseSpec extends FlatSpec with Matchers {
+  protected val sc = BaseSpec.sc
+  protected val sqlContext = BaseSpec.sqlContext
+
+  protected val LocalDynamoDBEndpoint = "http://localhost:8000"
+  protected val TestUsersTableName = "test_users"
+  protected val UserIdKey = "user_id"
+  protected val UsernameKey = "username"
+
+  override def withFixture(test: NoArgTest): Outcome = {
+    initializeTestUsersTable()
+    super.withFixture(test)
+  }
+
+  private def initializeTestUsersTable(): Unit = {
+    val amazonDynamoDBClient = new AmazonDynamoDBClient()
+    amazonDynamoDBClient.setEndpoint(LocalDynamoDBEndpoint)
+
+    val dynamodb = new DynamoDB(amazonDynamoDBClient)
+
+    try {
+      dynamodb.getTable(TestUsersTableName).delete()
+    } catch {
+      case _: ResourceNotFoundException => // pass
+    }
+
+    val createTableRequest = new CreateTableRequest()
+      .withTableName(TestUsersTableName)
+      .withAttributeDefinitions(Seq(new AttributeDefinition(UserIdKey, "N")))
+      .withKeySchema(Seq(new KeySchemaElement(UserIdKey, "HASH")))
+      .withProvisionedThroughput(new ProvisionedThroughput(10L, 10L))
+
+    val table = dynamodb.createTable(createTableRequest)
+
+    assert(table.getTableName == TestUsersTableName)
+
+    val items = Seq(
+      new Item().withNumber(UserIdKey, 1).withString(UsernameKey, "a"),
+      new Item().withNumber(UserIdKey, 2).withString(UsernameKey, "b"),
+      new Item().withNumber(UserIdKey, 3).withString(UsernameKey, "c"))
+
+    items.foreach(table.putItem)
+  }
+}
+
+object BaseSpec {
+  private val conf = new SparkConf().setAppName(this.getClass.getName).setMaster("local")
+  val sc = new SparkContext(conf)
+  val sqlContext = new SQLContext(sc)
+}

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationSpec.scala
@@ -1,15 +1,7 @@
 package com.github.traviscrawford.spark.dynamodb
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
-import com.amazonaws.services.dynamodbv2.document.DynamoDB
-import com.amazonaws.services.dynamodbv2.document.Item
-import com.amazonaws.services.dynamodbv2.model._
-import org.apache.spark._
 import org.apache.spark.sql._
 import org.apache.spark.sql.types._
-import org.scalatest._
-
-import scala.collection.JavaConversions._
 
 /** Test Spark's DynamoDB integration.
   *
@@ -22,25 +14,13 @@ import scala.collection.JavaConversions._
   *
   * @see http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tools.DynamoDBLocal.html
   */
-class DynamoDBRelationSpec() extends FlatSpec with Matchers {
+class DynamoDBRelationSpec() extends BaseSpec {
 
-  private val LocalDynamoDBEndpoint = "http://localhost:8000"
   private val EndpointKey = "endpoint"
-  private val TestUsersTableName = "test_users"
-  private val UserIdKey = "user_id"
-  private val UsernameKey = "username"
   private val TestUsersTableSchema = StructType(Seq(
     StructField(UserIdKey, LongType),
     StructField(UsernameKey, StringType)))
 
-  private val conf = new SparkConf().setAppName(this.getClass.getName).setMaster("local")
-  private val sc = new SparkContext(conf)
-  private val sqlContext = new SQLContext(sc)
-
-  override def withFixture(test: NoArgTest): Outcome = {
-    initializeTestUsersTable()
-    super.withFixture(test)
-  }
 
   "A DynamoDBRelation" should "infer the correct schema" in {
     val usersDF = sqlContext.read
@@ -102,35 +82,5 @@ class DynamoDBRelationSpec() extends FlatSpec with Matchers {
 
     sqlContext.sql("select * from users where username < 'b'").collect() should
       contain theSameElementsAs Seq(Row(1, "a"))
-  }
-
-  private def initializeTestUsersTable(): Unit = {
-    val amazonDynamoDBClient = new AmazonDynamoDBClient()
-    amazonDynamoDBClient.setEndpoint(LocalDynamoDBEndpoint)
-
-    val dynamodb = new DynamoDB(amazonDynamoDBClient)
-
-    try {
-      dynamodb.getTable(TestUsersTableName).delete()
-    } catch {
-      case _: ResourceNotFoundException => // pass
-    }
-
-    val createTableRequest = new CreateTableRequest()
-      .withTableName(TestUsersTableName)
-      .withAttributeDefinitions(Seq(new AttributeDefinition(UserIdKey, "N")))
-      .withKeySchema(Seq(new KeySchemaElement(UserIdKey, "HASH")))
-      .withProvisionedThroughput(new ProvisionedThroughput(10L, 10L))
-
-    val table = dynamodb.createTable(createTableRequest)
-
-    assert(table.getTableName == TestUsersTableName)
-
-    val items = Seq(
-      new Item().withNumber(UserIdKey, 1).withString(UsernameKey, "a"),
-      new Item().withNumber(UserIdKey, 2).withString(UsernameKey, "b"),
-      new Item().withNumber(UserIdKey, 3).withString(UsernameKey, "c"))
-
-    items.foreach(table.putItem)
   }
 }

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoScannerSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoScannerSpec.scala
@@ -1,0 +1,19 @@
+package com.github.traviscrawford.spark.dynamodb
+
+class DynamoScannerSpec extends BaseSpec {
+  "DynamoBackupJob" should "scan a table" in {
+    val items = DynamoScanner(sc,
+      table = TestUsersTableName,
+      totalSegments = 1,
+      pageSize = 1000,
+      maybeRateLimit = None,
+      maybeEndpoint = Some(LocalDynamoDBEndpoint))
+
+    val expected = Array(
+      "{\"user_id\":1,\"username\":\"a\"}",
+      "{\"user_id\":2,\"username\":\"b\"}",
+      "{\"user_id\":3,\"username\":\"c\"}")
+
+    items.collect() should contain theSameElementsAs expected
+  }
+}


### PR DESCRIPTION
Like most NoSQL databases, DynamoDB does not strictly enforce schemas. For
this reason it may not be appropriate to load your DynamoDB tables as Spark
DataFrames. Here we add support for getting the contents of a DynamoDB table
as an `RDD[String]` containing stringified JSON.