### PR TITLE
Refactor into BaseScanner

### DIFF
--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
@@ -1,0 +1,35 @@
+package com.github.traviscrawford.spark.dynamodb
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.Region
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import com.amazonaws.services.dynamodbv2.document.Table
+import org.slf4j.LoggerFactory
+
+
+private[dynamodb] trait BaseScanner {
+  private val log = LoggerFactory.getLogger(this.getClass)
+
+  def getTable(
+    tableName: String,
+    maybeCredentials: Option[String],
+    maybeRegion: Option[String],
+    maybeEndpoint: Option[String])
+  : Table = {
+
+    val amazonDynamoDBClient = maybeCredentials match {
+      case Some(credentialsClassName) =>
+        log.info(s"Using AWSCredentialsProvider $credentialsClassName")
+        val credentials = Class.forName(credentialsClassName)
+          .newInstance().asInstanceOf[AWSCredentialsProvider]
+        new AmazonDynamoDBClient(credentials)
+      case None => new AmazonDynamoDBClient()
+    }
+
+    maybeRegion.foreach(r => amazonDynamoDBClient.setRegion(Region.getRegion(Regions.fromName(r))))
+    maybeEndpoint.foreach(amazonDynamoDBClient.setEndpoint) // for tests
+    new DynamoDB(amazonDynamoDBClient).getTable(tableName)
+  }
+}

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoScanner.scala
@@ -16,7 +16,7 @@ import scala.collection.JavaConversions.asScalaIterator
   * For details, see:
   * http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScanGuidelines.html
   */
-object DynamoScanner {
+object DynamoScanner extends BaseScanner {
   private val log = LoggerFactory.getLogger(this.getClass)
 
   def apply(
@@ -52,7 +52,7 @@ object DynamoScanner {
       RateLimiter.create(rateLimit)
     })
 
-    val table = DynamoDBRelation.getTable(
+    val table = getTable(
       tableName = config.table,
       maybeCredentials = config.maybeCredentials,
       maybeRegion = config.maybeRegion,


### PR DESCRIPTION
Initially this project started as a Spark SQL data source, and over time has
added an RDD-based scanner too. Here we refactor the common scanner parts into
`BaseScanner` so they can more easily be shared.