### PR TITLE
Explicitly set guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,11 @@
       <version>1.10.68</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>18.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>util-app_2.11</artifactId>
       <version>6.34.0</version>


### PR DESCRIPTION
Hi Travis,

We're trying to use your DataFrame connector, but we were hitting a guava incompatibility issue:

```
diagnostics: User class threw exception: org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 0.0 failed 4 times, most recent failure: Lost task 0.3 in stage 0.0 (TID 3, ip-172-18-49-63.ec2.internal, executor 2): java.lang.NoSuchMethodError: __shaded_by_pants__.com.google.common.util.concurrent.RateLimiter.acquire(I)V
```

@sboora found an old guava version buried deep in the dependency graph carried in by Spark. By setting the guava version explicitly, Maven resolved to the newer version, and our incompatibility woes were over.
