### PR TITLE
Add filter_expression option for server side filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ For details about Spark SQL schemas, see
 | `segments` | Number of segments to scan the DynamoDB table with. |
 | `aws_credentials_provider` | Class name of the AWS credentials provider to use when connecting to DynamoDB. |
 | `endpoint` | DynamoDB client endpoint in `http://localhost:8000` format. This is generally not needed and intended for unit tests. |
+| `filter_expression` | DynamoDB scan filter expression to be performed server-side. This allows a partial table read into Spark. |
 
 ## RDD Usage
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,38 @@ For details about Spark SQL schemas, see
 | `segments` | Number of segments to scan the DynamoDB table with. |
 | `aws_credentials_provider` | Class name of the AWS credentials provider to use when connecting to DynamoDB. |
 | `endpoint` | DynamoDB client endpoint in `http://localhost:8000` format. This is generally not needed and intended for unit tests. |
-| `filter_expression` | DynamoDB scan filter expression to be performed server-side. This allows a partial table read into Spark. |
+| `filter_expression` | DynamoDB scan filter expression to be performed server-side. |
+
+#### Filter Expressions
+
+The `filter_expression` reader option allows you to pass filters directly to DynamoDB to be performed "server-side". That is,
+to be performed by DynamoDB servers before anything is loaded into Spark. In essence, this shifts load from your Spark
+instances onto your table-dedicated DynamoDB instances. This may be beneficial if you are using a shared Spark cluster and
+need to load a partial dataset from a large DynamoDB table.
+
+```
+import com.github.traviscrawford.spark.dynamodb._
+
+// Run server-side filter with string value (operations supported: =, >, <, >=, <=, <>)
+val tcUsers = sqlContext.read
+  // NOTE: No quotes (') around string value
+  .option("filter_expression", "username = tc")
+  .dynamodb("users")
+  
+// Strings can also use begins_with
+val beginsWithTCUsers = sqlConfext.read
+  // NOTE: No quotes (') around string value
+  .option("filter_Expression", "begins_with(username, tc)")
+  .dynamodb("users")
+
+// Run server-side filter with number value (operations supported: =, >, <, >=, <=, <>)
+val highLoginUsers = sqlContext.read
+  .option("filter_expression", "num_logins > 100")
+  .dynamodb("users")
+```
+
+For more information on DynamoDB Scan filters, see the AWS documentation [here](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.FilterExpression).
+
 
 ## RDD Usage
 

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
@@ -11,7 +11,7 @@ import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 private[dynamodb] trait BaseScanner {
   private val log = LoggerFactory.getLogger(this.getClass)
@@ -58,9 +58,9 @@ private[dynamodb] trait BaseScanner {
     config.maybeFilterExpression.map(filterExpression => ParsedFilterExpression(filterExpression))
       .foreach(parsedExpr => {
         scanSpec.withFilterExpression(parsedExpr.expression)
-        Option(parsedExpr.expressionNames).filter(!_.isEmpty)
+        Option(parsedExpr.expressionNames).filter(_.nonEmpty)
           .foreach(exprNames => scanSpec.withNameMap(exprNames.asJava))
-        Option(parsedExpr.expressionValues).filter(!_.isEmpty)
+        Option(parsedExpr.expressionValues).filter(_.nonEmpty)
           .foreach(exprValues => scanSpec.withValueMap(exprValues.asJava))
       })
     scanSpec

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
@@ -56,10 +56,13 @@ private[dynamodb] trait BaseScanner {
       .foreach(requiredColumns => scanSpec.withProjectionExpression(requiredColumns.mkString(",")))
     // Parse any filter expression passed in as an option
     config.maybeFilterExpression.map(filterExpression => ParsedFilterExpression(filterExpression))
-      .foreach(parsedFilterExpression =>
-        scanSpec.withFilterExpression(parsedFilterExpression.expression)
-          .withNameMap(parsedFilterExpression.expressionNames.asJava)
-          .withValueMap(parsedFilterExpression.expressionValues.asJava))
+      .foreach(parsedExpr => {
+        scanSpec.withFilterExpression(parsedExpr.expression)
+        Option(parsedExpr.expressionNames).filter(!_.isEmpty)
+          .foreach(exprNames => scanSpec.withNameMap(exprNames.asJava))
+        Option(parsedExpr.expressionValues).filter(!_.isEmpty)
+          .foreach(exprValues => scanSpec.withValueMap(exprValues.asJava))
+      })
     scanSpec
   }
 }

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
@@ -8,6 +8,8 @@ import com.amazonaws.services.dynamodbv2.document.DynamoDB
 import com.amazonaws.services.dynamodbv2.document.Table
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
 import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+import com.amazonaws.services.dynamodbv2.xspec.ScanExpressionSpec
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 
@@ -44,11 +46,15 @@ private[dynamodb] trait BaseScanner {
   }
 
   def getScanSpec(config: ScanConfig): ScanSpec = {
-    new ScanSpec()
+    val scanSpec = new ScanSpec()
       .withMaxPageSize(config.pageSize)
       .withReturnConsumedCapacity(ReturnConsumedCapacity.TOTAL)
       .withTotalSegments(config.totalSegments)
       .withSegment(config.segment)
+
+    config.maybeRequiredColumns
+      .foreach(requiredColumns => scanSpec.withProjectionExpression(requiredColumns.mkString(",")))
+    scanSpec
   }
 }
 

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DefaultSource.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DefaultSource.scala
@@ -32,6 +32,7 @@ private[dynamodb] class DefaultSource
 
     DynamoDBRelation(
       tableName = tableName,
+      maybeFilterExpression = parameters.get("filter_expression"),
       maybePageSize = parameters.get("page_size"),
       maybeRegion = parameters.get("region"),
       maybeSegments = parameters.get("segments"),

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
@@ -3,7 +3,6 @@ package com.github.traviscrawford.spark.dynamodb
 import java.util.concurrent.atomic.AtomicLong
 
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
-import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder
 import com.google.common.util.concurrent.RateLimiter
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
@@ -33,6 +32,7 @@ import scala.util.control.NonFatal
   */
 private[dynamodb] case class DynamoDBRelation(
   tableName: String,
+  maybeFilterExpression: Option[String],
   maybePageSize: Option[String],
   maybeSegments: Option[String],
   maybeRateLimit: Option[Int],
@@ -80,6 +80,7 @@ private[dynamodb] case class DynamoDBRelation(
         pageSize = pageSize,
         maybeSchema = Some(schema),
         maybeRequiredColumns = Some(requiredColumns),
+        maybeFilterExpression = maybeFilterExpression,
         maybeRateLimit = maybeRateLimit,
         maybeCredentials = maybeCredentials,
         maybeRegion = maybeRegion,

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
@@ -98,18 +98,6 @@ private[dynamodb] case class DynamoDBRelation(
       .flatMap(scan)
   }
 
-  override def getScanSpec(config: ScanConfig): ScanSpec = {
-    config.maybeRequiredColumns match {
-      case Some(requiredColumns) =>
-        val expressionSpecBuilder =
-          new ExpressionSpecBuilder().addProjections(requiredColumns: _*)
-        super
-          .getScanSpec(config)
-          .withExpressionSpec(expressionSpecBuilder.buildForScan())
-      case None => super.getScanSpec(config)
-    }
-  }
-
   def scan(config: ScanConfig): Iterator[Row] = {
     val scanSpec = getScanSpec(config)
     val table = getTable(config)

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpression.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpression.scala
@@ -1,0 +1,41 @@
+package com.github.traviscrawford.spark.dynamodb
+
+/** Simple parser for filter_expression options.
+  *
+  * This will add Dynamo indirection so that reserved keywords can
+  * be handled in filter expressions.
+  */
+private object ParsedFilterExpression {
+
+  private val CompareLongExpr = """(\w+) (=|>|<|>=|<=|<>) (\d+)""".r
+  private val CompareStringExpr = """(\w+) (=|>|<|>=|<=|<>) (\w+)""".r
+  private val BeginsWithExpr = """begins_with\((\w+), (\w+)\)""".r
+
+  def apply(filterExpression: String): ParsedFilterExpression = {
+    filterExpression match {
+      case CompareLongExpr(fieldName, operator, fieldValue) =>
+        ParsedFilterExpression(s"#$fieldName $operator :$fieldName",
+          Map(s"#$fieldName" -> s"$fieldName"),
+          Map(s":$fieldName" -> Long.box(fieldValue.toLong)))
+      case CompareStringExpr(fieldName, operator, fieldValue) =>
+        ParsedFilterExpression(s"#$fieldName $operator :$fieldName",
+          Map(s"#$fieldName" -> s"$fieldName"),
+          Map(s":$fieldName" -> s"$fieldValue"))
+      case BeginsWithExpr(fieldName, fieldValue) =>
+        ParsedFilterExpression(s"begins_with(#$fieldName, :$fieldName)",
+          Map(s"#$fieldName" -> s"$fieldName"),
+          Map(s":$fieldName" -> s"$fieldValue"))
+      // By default, just keep the whole filterExpression without substitutions
+      case _ =>
+        ParsedFilterExpression(filterExpression,
+          Map.empty[String, String],
+          Map.empty[String, AnyRef])
+    }
+  }
+}
+
+private[dynamodb] case class ParsedFilterExpression(
+  expression: String,
+  expressionNames: Map[String, String],
+  expressionValues: Map[String, AnyRef]
+)

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpression.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpression.scala
@@ -4,6 +4,9 @@ package com.github.traviscrawford.spark.dynamodb
   *
   * This will add Dynamo indirection so that reserved keywords can
   * be handled in filter expressions.
+  *
+  * Regex matching inspired by:
+  * https://ikaisays.com/2009/04/04/using-pattern-matching-with-regular-expressions-in-scala/
   */
 private object ParsedFilterExpression {
 

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationIntegrationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationIntegrationSpec.scala
@@ -71,5 +71,18 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     spark.sql("select * from users where username < 'b'").collect() should
       contain theSameElementsAs Seq(Row(1, "a"))
   }
+
+  it should "apply server side filter_expressions" in {
+    val df = spark.read
+      .schema(TestUsersTableSchema)
+      .option(EndpointKey, LocalDynamoDBEndpoint)
+      .option("filter_expression", "username <> b")
+      .dynamodb(TestUsersTableName)
+
+    df.createOrReplaceTempView("users")
+
+    spark.sql("select * from users where username <> 'c'").collect() should
+      contain theSameElementsAs Seq(Row(1, "a"))
+  }
 }
 

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpressionSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpressionSpec.scala
@@ -34,35 +34,35 @@ class ParsedFilterExpressionSpec extends FlatSpec with Matchers {
     parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
   }
 
-  it should "corrector parse greaterThan expressions" in {
+  it should "correctly parse greaterThan expressions" in {
     val parsedExpr = ParsedFilterExpression("name > myName")
     parsedExpr.expression should be ("#name > :name")
     parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
     parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
   }
 
-  it should "corrector parse greaterThanOrEquals expressions" in {
+  it should "correctly parse greaterThanOrEquals expressions" in {
     val parsedExpr = ParsedFilterExpression("name >= myName")
     parsedExpr.expression should be ("#name >= :name")
     parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
     parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
   }
 
-  it should "corrector parse lessThan expressions" in {
+  it should "correctly parse lessThan expressions" in {
     val parsedExpr = ParsedFilterExpression("name < myName")
     parsedExpr.expression should be ("#name < :name")
     parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
     parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
   }
 
-  it should "corrector parse lessThanOrEqual expressions" in {
+  it should "correctly parse lessThanOrEqual expressions" in {
     val parsedExpr = ParsedFilterExpression("name <= myName")
     parsedExpr.expression should be ("#name <= :name")
     parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
     parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
   }
 
-  it should "corrector parse notEquals expressions" in {
+  it should "correctly parse notEquals expressions" in {
     val parsedExpr = ParsedFilterExpression("name <> myName")
     parsedExpr.expression should be ("#name <> :name")
     parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpressionSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpressionSpec.scala
@@ -1,0 +1,78 @@
+package com.github.traviscrawford.spark.dynamodb
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+/** BDD tests for [[ParsedFilterExpression]]. */
+class ParsedFilterExpressionSpec extends FlatSpec with Matchers {
+
+  "ParsedFilterExpression" should "correctly parse compare string expressions" in {
+    val parsedExpr = ParsedFilterExpression("name = myName")
+    parsedExpr.expression should be ("#name = :name")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
+  }
+
+  it should "correctly parse compare long expressions" in {
+    val parsedExpr = ParsedFilterExpression("value = 1")
+    parsedExpr.expression should be ("#value = :value")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#value" -> "value")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":value" -> Long.box(1L))
+  }
+
+  it should "correctly parse begins_with expressions" in {
+    val parsedExpr = ParsedFilterExpression("begins_with(name, myName)")
+    parsedExpr.expression should be ("begins_with(#name, :name)")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
+  }
+
+  it should "correctly parse equals expressions" in {
+    val parsedExpr = ParsedFilterExpression("name = myName")
+    parsedExpr.expression should be ("#name = :name")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
+  }
+
+  it should "corrector parse greaterThan expressions" in {
+    val parsedExpr = ParsedFilterExpression("name > myName")
+    parsedExpr.expression should be ("#name > :name")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
+  }
+
+  it should "corrector parse greaterThanOrEquals expressions" in {
+    val parsedExpr = ParsedFilterExpression("name >= myName")
+    parsedExpr.expression should be ("#name >= :name")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
+  }
+
+  it should "corrector parse lessThan expressions" in {
+    val parsedExpr = ParsedFilterExpression("name < myName")
+    parsedExpr.expression should be ("#name < :name")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
+  }
+
+  it should "corrector parse lessThanOrEqual expressions" in {
+    val parsedExpr = ParsedFilterExpression("name <= myName")
+    parsedExpr.expression should be ("#name <= :name")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
+  }
+
+  it should "corrector parse notEquals expressions" in {
+    val parsedExpr = ParsedFilterExpression("name <> myName")
+    parsedExpr.expression should be ("#name <> :name")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#name" -> "name")
+    parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
+  }
+
+  it should "handle expressions that it cannot parse" in {
+    val parsedExpr = ParsedFilterExpression("name = myName AND value = 1")
+    parsedExpr.expression should be ("name = myName AND value = 1")
+    parsedExpr.expressionNames shouldBe empty
+    parsedExpr.expressionValues shouldBe empty
+  }
+}


### PR DESCRIPTION
Hey Travis,

Sending you a small pull request to add `filter_expression` as a reader option. This allows you to push a scan filter expression to Dynamo to be performed "server side". The net effect is that you can perform partial table reads into Spark.

http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.FilterExpression

CC: @sboora @sachee 