### PR TITLE
Fix filter_expression parsing for string values with symbols

### DIFF
--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpression.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpression.scala
@@ -11,8 +11,8 @@ package com.github.traviscrawford.spark.dynamodb
 private object ParsedFilterExpression {
 
   private val CompareLongExpr = """(\w+) (=|>|<|>=|<=|<>) (\d+)""".r
-  private val CompareStringExpr = """(\w+) (=|>|<|>=|<=|<>) (\w+)""".r
-  private val BeginsWithExpr = """begins_with\((\w+), (\w+)\)""".r
+  private val CompareStringExpr = """(\w+) (=|>|<|>=|<=|<>) (\D+)""".r
+  private val BeginsWithExpr = """begins_with\((\w+), (\D+)\)""".r
 
   def apply(filterExpression: String): ParsedFilterExpression = {
     filterExpression match {

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpressionSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/ParsedFilterExpressionSpec.scala
@@ -13,6 +13,14 @@ class ParsedFilterExpressionSpec extends FlatSpec with Matchers {
     parsedExpr.expressionValues should contain theSameElementsAs Map(":name" -> "myName")
   }
 
+  it should "correctly parse compare string expressions with non-alphabetic characters" in {
+    val parsedExpr = ParsedFilterExpression("email = me_myself_i@domain.com")
+    parsedExpr.expression should be ("#email = :email")
+    parsedExpr.expressionNames should contain theSameElementsAs Map("#email" -> "email")
+    parsedExpr.expressionValues should contain theSameElementsAs
+      Map(":email" -> "me_myself_i@domain.com")
+  }
+
   it should "correctly parse compare long expressions" in {
     val parsedExpr = ParsedFilterExpression("value = 1")
     parsedExpr.expression should be ("#value = :value")


### PR DESCRIPTION
Hi @traviscrawford ,

Of course, when I went to use the `filter_expression` option, it failed for my use case.

Just a small modification for the parsing which will accept non-alphabetic symbols in string values.

Sorry for the inconvenience!