### PR TITLE
REGRESSION: Add indirection for projection expressions in ScanSpec

### DIFF
--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/BaseScanner.scala
@@ -8,10 +8,12 @@ import com.amazonaws.services.dynamodbv2.document.DynamoDB
 import com.amazonaws.services.dynamodbv2.document.Table
 import com.amazonaws.services.dynamodbv2.document.spec.ScanSpec
 import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+import com.amazonaws.services.dynamodbv2.xspec.ExpressionSpecBuilder
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.collection.JavaConverters.mapAsScalaMapConverter
 
 private[dynamodb] trait BaseScanner {
   private val log = LoggerFactory.getLogger(this.getClass)
@@ -52,17 +54,31 @@ private[dynamodb] trait BaseScanner {
       .withTotalSegments(config.totalSegments)
       .withSegment(config.segment)
 
-    config.maybeRequiredColumns
-      .foreach(requiredColumns => scanSpec.withProjectionExpression(requiredColumns.mkString(",")))
+    // Parse any projection expressions passed in
+    val exprSpecBuilder = config.maybeRequiredColumns
+      .map(requiredColumns => new ExpressionSpecBuilder().addProjections(requiredColumns: _*))
+    val parsedProjectionExpr = exprSpecBuilder.map(xSpecBuilder => xSpecBuilder.buildForScan())
+    val projectionNameMap = parsedProjectionExpr.flatMap(projExpr => Option(projExpr.getNameMap))
+      .map(_.asScala.toMap).getOrElse(Map.empty)
+    val projectionValueMap = parsedProjectionExpr.flatMap(projExpr => Option(projExpr.getValueMap))
+      .map(_.asScala.toMap).getOrElse(Map.empty)
+    parsedProjectionExpr.foreach(expr =>
+      scanSpec.withProjectionExpression(expr.getProjectionExpression))
+
     // Parse any filter expression passed in as an option
-    config.maybeFilterExpression.map(filterExpression => ParsedFilterExpression(filterExpression))
-      .foreach(parsedExpr => {
-        scanSpec.withFilterExpression(parsedExpr.expression)
-        Option(parsedExpr.expressionNames).filter(_.nonEmpty)
-          .foreach(exprNames => scanSpec.withNameMap(exprNames.asJava))
-        Option(parsedExpr.expressionValues).filter(_.nonEmpty)
-          .foreach(exprValues => scanSpec.withValueMap(exprValues.asJava))
-      })
+    val parsedFilterExpr = config.maybeFilterExpression
+      .map(filterExpression => ParsedFilterExpression(filterExpression))
+    val filterNameMap = parsedFilterExpr.map(_.expressionNames).getOrElse(Map.empty)
+    val filterValueMap = parsedFilterExpr.map(_.expressionValues).getOrElse(Map.empty)
+    parsedFilterExpr.foreach(expr =>
+      scanSpec.withFilterExpression(expr.expression))
+
+    // Combine parsed name and value maps from the projections and filter expressions
+    val nameMap = projectionNameMap ++ filterNameMap
+    Option(nameMap).filter(_.nonEmpty).foreach(nMap => scanSpec.withNameMap(nMap.asJava))
+    val valueMap = projectionValueMap ++ filterValueMap
+    Option(valueMap).filter(_.nonEmpty).foreach(vMap => scanSpec.withValueMap(vMap.asJava))
+
     scanSpec
   }
 }

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/BaseIntegrationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/BaseIntegrationSpec.scala
@@ -27,6 +27,7 @@ trait BaseIntegrationSpec extends FlatSpec with Matchers {
   protected val TestUsersTableName = "test_users"
   protected val UserIdKey = "user_id"
   protected val UsernameKey = "username"
+  protected val CreatedAtKey = "__createdAt"
 
   override def withFixture(test: NoArgTest): Outcome = {
     initializeTestUsersTable()
@@ -56,9 +57,9 @@ trait BaseIntegrationSpec extends FlatSpec with Matchers {
     assert(table.getTableName == TestUsersTableName)
 
     val items = Seq(
-      new Item().withNumber(UserIdKey, 1).withString(UsernameKey, "a"),
-      new Item().withNumber(UserIdKey, 2).withString(UsernameKey, "b"),
-      new Item().withNumber(UserIdKey, 3).withString(UsernameKey, "c"))
+      new Item().withNumber(UserIdKey, 1).withString(UsernameKey, "a").withNumber(CreatedAtKey, 11),
+      new Item().withNumber(UserIdKey, 2).withString(UsernameKey, "b").withNumber(CreatedAtKey, 22),
+      new Item().withNumber(UserIdKey, 3).withString(UsernameKey, "c").withNumber(CreatedAtKey, 33))
 
     items.foreach(table.putItem)
   }

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationIntegrationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationIntegrationSpec.scala
@@ -7,6 +7,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
 
   private val EndpointKey = "endpoint"
   private val TestUsersTableSchema = StructType(Seq(
+    StructField(CreatedAtKey, LongType),
     StructField(UserIdKey, LongType),
     StructField(UsernameKey, StringType)))
 
@@ -24,7 +25,8 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
       .option("rate_limit_per_segment", "1")
       .dynamodb(TestUsersTableName)
 
-    usersDF.collect() should contain theSameElementsAs Seq(Row(1, "a"), Row(2, "b"), Row(3, "c"))
+    usersDF.collect() should contain theSameElementsAs
+      Seq(Row(11, 1, "a"), Row(22, 2, "b"), Row(33, 3, "c"))
   }
 
   it should "get attributes in the user-provided schema" in {
@@ -33,7 +35,8 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
       .option(EndpointKey, LocalDynamoDBEndpoint)
       .dynamodb(TestUsersTableName)
 
-    usersDF.collect() should contain theSameElementsAs Seq(Row(1, "a"), Row(2, "b"), Row(3, "c"))
+    usersDF.collect() should contain theSameElementsAs
+      Seq(Row(11, 1, "a"), Row(22, 2, "b"), Row(33, 3, "c"))
   }
 
   it should "support EqualTo filters" in {
@@ -45,7 +48,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users where username = 'a'").collect() should
-      contain theSameElementsAs Seq(Row(1, "a"))
+      contain theSameElementsAs Seq(Row(11, 1, "a"))
   }
 
   it should "support GreaterThan filters" in {
@@ -57,7 +60,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users where username > 'b'").collect() should
-      contain theSameElementsAs Seq(Row(3, "c"))
+      contain theSameElementsAs Seq(Row(33, 3, "c"))
   }
 
   it should "support LessThan filters" in {
@@ -69,7 +72,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users where username < 'b'").collect() should
-      contain theSameElementsAs Seq(Row(1, "a"))
+      contain theSameElementsAs Seq(Row(11, 1, "a"))
   }
 
   it should "apply server side filter_expressions" in {
@@ -82,7 +85,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users where username <> 'c'").collect() should
-      contain theSameElementsAs Seq(Row(1, "a"))
+      contain theSameElementsAs Seq(Row(11, 1, "a"))
   }
 }
 

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoScannerIntegrationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoScannerIntegrationSpec.scala
@@ -10,9 +10,9 @@ class DynamoScannerIntegrationSpec extends BaseIntegrationSpec {
       maybeEndpoint = Some(LocalDynamoDBEndpoint))
 
     val expected = Array(
-      "{\"user_id\":1,\"username\":\"a\"}",
-      "{\"user_id\":2,\"username\":\"b\"}",
-      "{\"user_id\":3,\"username\":\"c\"}")
+      "{\"__createdAt\":11,\"user_id\":1,\"username\":\"a\"}",
+      "{\"__createdAt\":22,\"user_id\":2,\"username\":\"b\"}",
+      "{\"__createdAt\":33,\"user_id\":3,\"username\":\"c\"}")
 
     items.collect() should contain theSameElementsAs expected
   }


### PR DESCRIPTION
After running some tests, I realized that one of my previous changes regressed how projection expressions were handled. Namely, that unparse-able projection expressions were no longer using name map indirection.

I modified the tests to check for this case and added a fix.