### PR TITLE
Add support for Boolean type and tests for Boolean schema infer

### DIFF
--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/ItemConverter.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/ItemConverter.scala
@@ -22,6 +22,7 @@ private[dynamodb] object ItemConverter {
         case "long" => item.getLong(field.name)
         case "float" => item.getFloat(field.name)
         case "double" => item.getDouble(field.name)
+        case "boolean" => item.getBoolean(field.name)
         case "array" => getArrayValue(field, item)
         case _ => throw new IllegalArgumentException(
           s"Unexpected data type ${field.dataType.typeName} field: $field item: $item")
@@ -42,6 +43,7 @@ private[dynamodb] object ItemConverter {
       case LongType => getList(field.name).map(_.longValue())
       case FloatType => getList(field.name).map(_.floatValue())
       case DoubleType => getList(field.name).map(_.doubleValue())
+      case BooleanType => item.getList[Boolean](field.name).asScala.toList
       case _ => throw new IllegalArgumentException(
         s"Unexpected array element type ${field.dataType.typeName} field: $field item: $item")
     }

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/BaseIntegrationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/BaseIntegrationSpec.scala
@@ -28,6 +28,7 @@ trait BaseIntegrationSpec extends FlatSpec with Matchers {
   protected val UserIdKey = "user_id"
   protected val UsernameKey = "username"
   protected val CreatedAtKey = "__createdAt"
+  protected val IsAdmin = "is_admin"
 
   override def withFixture(test: NoArgTest): Outcome = {
     initializeTestUsersTable()
@@ -57,9 +58,24 @@ trait BaseIntegrationSpec extends FlatSpec with Matchers {
     assert(table.getTableName == TestUsersTableName)
 
     val items = Seq(
-      new Item().withNumber(UserIdKey, 1).withString(UsernameKey, "a").withNumber(CreatedAtKey, 11),
-      new Item().withNumber(UserIdKey, 2).withString(UsernameKey, "b").withNumber(CreatedAtKey, 22),
-      new Item().withNumber(UserIdKey, 3).withString(UsernameKey, "c").withNumber(CreatedAtKey, 33))
+      new Item()
+        .withNumber(UserIdKey, 1)
+        .withString(UsernameKey, "a")
+        .withNumber(CreatedAtKey, 11)
+        .withBoolean(IsAdmin, true),
+
+      new Item()
+        .withNumber(UserIdKey, 2)
+        .withString(UsernameKey, "b")
+        .withNumber(CreatedAtKey, 22)
+        .withBoolean(IsAdmin, false),
+
+      new Item()
+        .withNumber(UserIdKey, 3)
+        .withString(UsernameKey, "c")
+        .withNumber(CreatedAtKey, 33)
+        .withBoolean(IsAdmin, false)
+    )
 
     items.foreach(table.putItem)
   }

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationIntegrationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelationIntegrationSpec.scala
@@ -8,6 +8,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
   private val EndpointKey = "endpoint"
   private val TestUsersTableSchema = StructType(Seq(
     StructField(CreatedAtKey, LongType),
+    StructField(IsAdmin, BooleanType),
     StructField(UserIdKey, LongType),
     StructField(UsernameKey, StringType)))
 
@@ -26,7 +27,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
       .dynamodb(TestUsersTableName)
 
     usersDF.collect() should contain theSameElementsAs
-      Seq(Row(11, 1, "a"), Row(22, 2, "b"), Row(33, 3, "c"))
+      Seq(Row(11, true, 1, "a"), Row(22, false, 2, "b"), Row(33, false, 3, "c"))
   }
 
   it should "get attributes in the user-provided schema" in {
@@ -36,7 +37,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
       .dynamodb(TestUsersTableName)
 
     usersDF.collect() should contain theSameElementsAs
-      Seq(Row(11, 1, "a"), Row(22, 2, "b"), Row(33, 3, "c"))
+      Seq(Row(11, true, 1, "a"), Row(22, false, 2, "b"), Row(33, false, 3, "c"))
   }
 
   it should "support EqualTo filters" in {
@@ -48,7 +49,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users where username = 'a'").collect() should
-      contain theSameElementsAs Seq(Row(11, 1, "a"))
+      contain theSameElementsAs Seq(Row(11, true, 1, "a"))
   }
 
   it should "support GreaterThan filters" in {
@@ -60,7 +61,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users where username > 'b'").collect() should
-      contain theSameElementsAs Seq(Row(33, 3, "c"))
+      contain theSameElementsAs Seq(Row(33, false, 3, "c"))
   }
 
   it should "support LessThan filters" in {
@@ -72,7 +73,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users where username < 'b'").collect() should
-      contain theSameElementsAs Seq(Row(11, 1, "a"))
+      contain theSameElementsAs Seq(Row(11, true, 1, "a"))
   }
 
   it should "apply server side filter_expressions" in {
@@ -85,7 +86,7 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users where username <> 'c'").collect() should
-      contain theSameElementsAs Seq(Row(11, 1, "a"))
+      contain theSameElementsAs Seq(Row(11, true, 1, "a"))
   }
 
   it should "apply server side filter_expressions equals" in {
@@ -98,6 +99,6 @@ class DynamoDBRelationIntegrationSpec() extends BaseIntegrationSpec {
     df.createOrReplaceTempView("users")
 
     spark.sql("select * from users").collect() should
-      contain theSameElementsAs Seq(Row(11, 1, "a"))
+      contain theSameElementsAs Seq(Row(11, true, 1, "a"))
   }
 }

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoScannerIntegrationSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/DynamoScannerIntegrationSpec.scala
@@ -10,9 +10,9 @@ class DynamoScannerIntegrationSpec extends BaseIntegrationSpec {
       maybeEndpoint = Some(LocalDynamoDBEndpoint))
 
     val expected = Array(
-      "{\"__createdAt\":11,\"user_id\":1,\"username\":\"a\"}",
-      "{\"__createdAt\":22,\"user_id\":2,\"username\":\"b\"}",
-      "{\"__createdAt\":33,\"user_id\":3,\"username\":\"c\"}")
+      "{\"is_admin\":true,\"__createdAt\":11,\"user_id\":1,\"username\":\"a\"}",
+      "{\"is_admin\":false,\"__createdAt\":22,\"user_id\":2,\"username\":\"b\"}",
+      "{\"is_admin\":false,\"__createdAt\":33,\"user_id\":3,\"username\":\"c\"}")
 
     items.collect() should contain theSameElementsAs expected
   }

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/ItemConverterSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/ItemConverterSpec.scala
@@ -21,6 +21,8 @@ class ItemConverterSpec extends FlatSpec with Matchers {
       .withList("testFloatList", Seq(3.3f).asJava)
       .withDouble("testDouble", 4.4d)
       .withList("testDoubleList", Seq(4.4d).asJava)
+      .withBoolean("testBoolean", true)
+      .withList("testDoubleListList", Seq(true, false, true).asJava)
 
     val schema = StructType(Seq(
       StructField("testString", StringType),
@@ -32,10 +34,12 @@ class ItemConverterSpec extends FlatSpec with Matchers {
       StructField("testFloat", FloatType),
       StructField("testFloatList", ArrayType(FloatType)),
       StructField("testDouble", DoubleType),
-      StructField("testDoubleList", ArrayType(DoubleType))
+      StructField("testDoubleList", ArrayType(DoubleType)),
+      StructField("testBoolean", BooleanType),
+      StructField("testDoubleListList", ArrayType(BooleanType))
     ))
 
     ItemConverter.toRow(item, schema) shouldBe
-      Row("a", Seq("a"), 1, Seq(1), 2L, Seq(2L), 3.3f, Seq(3.3f), 4.4d, Seq(4.4d))
+      Row("a", Seq("a"), 1, Seq(1), 2L, Seq(2L), 3.3f, Seq(3.3f), 4.4d, Seq(4.4d), true, Seq(true, false, true))
   }
 }


### PR DESCRIPTION
__WHY__:
Potentially related to #21.
The library can't work with Boolean fields in DynamoDB.

__WHAT__:
- Support for Boolean fields and arrays of Booleans added.
- Test `ItemConverterSpec` extended to cover Booleans.
- A Boolean field added to the integration tests.