### PR TITLE
use user provided AWS access and secret key

### DIFF
--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoBackupJob.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoBackupJob.scala
@@ -32,11 +32,12 @@ object DynamoBackupJob extends Job {
     val maybeCredentials = if (credentials.isDefined) Some(credentials()) else None
     val maybeRateLimit = if (rateLimit.isDefined) Some(rateLimit()) else None
     val maybeRegion = if (region.isDefined) Some(region()) else None
-
+    val awsAccessKey = None
+    val awsSecretKey = None
     if (overwrite()) deleteOutputPath(output())
 
     DynamoScanner(sc, table(), totalSegments(), pageSize(),
-      maybeCredentials, maybeRateLimit, maybeRegion).saveAsTextFile(output())
+      maybeCredentials, awsAccessKey, awsSecretKey, maybeRateLimit, maybeRegion).saveAsTextFile(output())
   }
 
   private def deleteOutputPath(output: String): Unit = {

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoDBRelation.scala
@@ -39,6 +39,8 @@ private[dynamodb] case class DynamoDBRelation(
   maybeRegion: Option[String],
   maybeSchema: Option[StructType],
   maybeCredentials: Option[String] = None,
+  awsAccessKey: Option[String] = None,
+  awsSecretKey: Option[String] = None,
   maybeEndpoint: Option[String])
   (@transient val sqlContext: SQLContext)
   extends BaseRelation with PrunedScan with BaseScanner {
@@ -46,7 +48,7 @@ private[dynamodb] case class DynamoDBRelation(
   private val log = LoggerFactory.getLogger(this.getClass)
 
   @transient private lazy val Table = getTable(
-    tableName, maybeCredentials, maybeRegion, maybeEndpoint)
+    tableName, maybeCredentials, awsAccessKey, awsSecretKey, maybeRegion, maybeEndpoint)
 
   private val pageSize = Integer.parseInt(maybePageSize.getOrElse("1000"))
 
@@ -84,6 +86,8 @@ private[dynamodb] case class DynamoDBRelation(
         maybeFilterExpression = maybeFilterExpression,
         maybeRateLimit = maybeRateLimit,
         maybeCredentials = maybeCredentials,
+        awsAccessKey = awsAccessKey,
+        awsSecretKey = awsSecretKey,
         maybeRegion = maybeRegion,
         maybeEndpoint = maybeEndpoint)
     })

--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoScanner.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/DynamoScanner.scala
@@ -23,6 +23,8 @@ object DynamoScanner extends BaseScanner {
     totalSegments: Int,
     pageSize: Int,
     maybeCredentials: Option[String] = None,
+    awsAccessKey: Option[String] = None,
+    awsSecretKey: Option[String] = None,
     maybeRateLimit: Option[Int] = None,
     maybeRegion: Option[String] = None,
     maybeEndpoint: Option[String] = None)
@@ -37,6 +39,8 @@ object DynamoScanner extends BaseScanner {
         pageSize = pageSize,
         maybeRateLimit = maybeRateLimit,
         maybeCredentials = maybeCredentials,
+        awsAccessKey = awsAccessKey,
+        awsSecretKey = awsSecretKey,
         maybeRegion = maybeRegion,
         maybeEndpoint = maybeEndpoint)
     })


### PR DESCRIPTION
Add support for user provided AWS access and secret key. This is helpful if we want to use different credentials other than ones stored in the environment variables or default credentials file.