### PR TITLE
Ignore schema fields that are not present in the db item

### DIFF
--- a/src/main/scala/com/github/traviscrawford/spark/dynamodb/ItemConverter.scala
+++ b/src/main/scala/com/github/traviscrawford/spark/dynamodb/ItemConverter.scala
@@ -16,15 +16,21 @@ private[dynamodb] object ItemConverter {
 
   def toRow(item: Item, schema: StructType): Row = {
     val values: Seq[Any] = schema.map(field => {
-      field.dataType.typeName match {
-        case "string" => item.getString(field.name)
-        case "integer" => item.getInt(field.name)
-        case "long" => item.getLong(field.name)
-        case "float" => item.getFloat(field.name)
-        case "double" => item.getDouble(field.name)
-        case "array" => getArrayValue(field, item)
-        case _ => throw new IllegalArgumentException(
-          s"Unexpected data type ${field.dataType.typeName} field: $field item: $item")
+      if (item.hasAttribute(field.name)) {
+        field.dataType.typeName match {
+          case "string" => item.getString(field.name)
+          case "integer" => item.getInt(field.name)
+          case "long" => item.getLong(field.name)
+          case "float" => item.getFloat(field.name)
+          case "double" => item.getDouble(field.name)
+          case "array" => getArrayValue(field, item)
+          case _ => throw new IllegalArgumentException(
+            s"Unexpected data type ${field.dataType.typeName} field: $field item: $item")
+        }
+      } else {
+        // scalastyle:off null
+        null
+        // scalastyle:on null
       }
     })
 

--- a/src/test/scala/com/github/traviscrawford/spark/dynamodb/ItemConverterSpec.scala
+++ b/src/test/scala/com/github/traviscrawford/spark/dynamodb/ItemConverterSpec.scala
@@ -38,4 +38,35 @@ class ItemConverterSpec extends FlatSpec with Matchers {
     ItemConverter.toRow(item, schema) shouldBe
       Row("a", Seq("a"), 1, Seq(1), 2L, Seq(2L), 3.3f, Seq(3.3f), 4.4d, Seq(4.4d))
   }
+
+  it should "correctly transform an Item into a Row if item is missing a field" in {
+    val item = new Item()
+      .withList("testStringList", Seq("a").asJava)
+      .withInt("testInt", 1)
+      .withList("testIntList", Seq(1).asJava)
+      .withLong("testLong", 2L)
+      .withList("testLongList", Seq(2L).asJava)
+      .withFloat("testFloat", 3.3f)
+      .withList("testFloatList", Seq(3.3f).asJava)
+      .withDouble("testDouble", 4.4d)
+      .withList("testDoubleList", Seq(4.4d).asJava)
+
+    val schema = StructType(Seq(
+      StructField("testString", StringType),
+      StructField("testStringList", ArrayType(StringType)),
+      StructField("testInt", IntegerType),
+      StructField("testIntList", ArrayType(IntegerType)),
+      StructField("testLong", LongType),
+      StructField("testLongList", ArrayType(LongType)),
+      StructField("testFloat", FloatType),
+      StructField("testFloatList", ArrayType(FloatType)),
+      StructField("testDouble", DoubleType),
+      StructField("testDoubleList", ArrayType(DoubleType))
+    ))
+
+    // scalastyle:off null
+    ItemConverter.toRow(item, schema) shouldBe
+      Row(null, Seq("a"), 1, Seq(1), 2L, Seq(2L), 3.3f, Seq(3.3f), 4.4d, Seq(4.4d))
+    // scalastyle:on null
+  }
 }


### PR DESCRIPTION
Re-introduces the null check that was removed in this PR: https://github.com/traviscrawford/spark-dynamodb/pull/34. 

The new functionality throws if the schema is not 1-1 with what's in the database.


cc @sboora 