### PR TITLE
Create artifact with shaded guava library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             </goals>
             <configuration>
               <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>allinone</shadedClassifierName>
+              <shadedClassifierName>shaded-guava</shadedClassifierName>
               <artifactSet>
                 <includes>
                   <include>*:spark-dynamodb</include>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,35 @@
     <testSourceDirectory>src/test/scala</testSourceDirectory>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>allinone</shadedClassifierName>
+              <artifactSet>
+                <includes>
+                  <include>*:spark-dynamodb</include>
+                  <include>*:guava</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>shaded.com.google.common</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- http://central.sonatype.org/pages/apache-maven.html#performing-a-release-deployment -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -277,6 +306,11 @@
       <artifactId>scalatest_2.11</artifactId>
       <version>3.0.5</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Hi, this is in the first instance for discussion. There might be better ways of doing this.

What I am trying to do here is to produce an artifact with a shaded guava library. Many clusters provide a terribly old version of guava (15.0). Which is a mess to sort out usually. An easy way around it is to produce a shaded version of it. The maven plugin creates a new artifact "spark-dynamodb-0.0.13-shaded-guava.jar" in which it moves packages  so that com.google.common becomes shaded.com.google.common. This allows the jar to be deployed using a new guava version without affecting the rest of the cluster.

It would be cool to have this produced automatically so that I don't need to maintain a fork. I am fairly sure other people would find it useful, too. In my specific use-case I needed it to make it work on AWS Glue, as the DynamicFrame connector was not flexible enough.

Happy to discuss and adapt as needed.